### PR TITLE
Add Python 3.7 + 3.8 Travis CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: python
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.6
-env:
-  - TOXENV=py35
-  - TOXENV=py36
+dist: xenial
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+
 install:
-  - pip install tox 
+  - pip install tox
+
 script:
   - tox
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36
+envlist = py35,py36,py37
 
 [testenv]
 extras =


### PR DESCRIPTION
- Considering using this module and want to make sure it's healthy in newer Pythons

TODO: Lot of warnings to fix.