### PR TITLE
Support strings without type indication

### DIFF
--- a/aiohttp_xmlrpc/client.py
+++ b/aiohttp_xmlrpc/client.py
@@ -70,14 +70,14 @@ class ServerProxy(object):
         except etree.DocumentInvalid:
             raise ValueError("Invalid body")
 
-        result = response.xpath("//params/param/value/*")
+        result = response.xpath("//params/param/value")
         if result:
             if len(result) < 2:
                 return xml2py(result[0])
 
             return [xml2py(item) for item in result]
 
-        fault = response.xpath("//fault/value/*")
+        fault = response.xpath("//fault/value")
         if fault:
             err = xml2py(fault[0])
 

--- a/aiohttp_xmlrpc/common.py
+++ b/aiohttp_xmlrpc/common.py
@@ -153,13 +153,20 @@ def xml2py(value):
                 lambda x: (x[0].text, x[1]),
                 zip(
                     p.xpath("./member/name"),
-                    map(xml2py, p.xpath("./member/value/*")),
+                    map(xml2py, p.xpath("./member/value")),
                 ),
             ),
         )
 
     def xml2array(p):
-        return list(map(xml2py, p.xpath("./data/value/*")))
+        return list(map(xml2py, p.xpath("./data/value")))
+
+    def unwrap_value(p):
+        try:
+            value = next(p.iterchildren())
+        except StopIteration:
+            value = p.text or ''
+        return xml2py(value)
 
     XML2PY_TYPES.update({
         "string": lambda x: str(x.text).strip(),
@@ -173,6 +180,7 @@ def xml2py(value):
         "int": lambda x: int(x.text),
         "i4": lambda x: int(x.text),
         "nil": lambda x: None,
+        "value": unwrap_value,
     })
 
     if isinstance(value, str):

--- a/aiohttp_xmlrpc/handler.py
+++ b/aiohttp_xmlrpc/handler.py
@@ -134,9 +134,7 @@ class XMLRPCView(View, metaclass=XMLRPCViewMeta):
         args = list(
             map(
                 xml2py,
-                xml_request.xpath(
-                    "//params/param/value/* | //params/param/value[not(*)]/text()",
-                ),
+                xml_request.xpath("//params/param/value"),
             ),
         )
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -81,37 +81,41 @@ CASES = [
 ]
 
 CASES_COMPAT = [
-    ("Hello world!", "Hello world!"),
+    ("Hello world!", "<value>Hello world!</value>"),
     (
         [[1, "a"]],
         (
-            "<array>"
-                "<data>"
-                    "<value>"
-                        "<array>"
-                            "<data>"
-                                "<value>"
-                                    "<i4>1</i4>"
-                                "</value>"
-                                "<value>"
-                                    "a"
-                                "</value>"
-                            "</data>"
-                        "</array>"
-                    "</value>"
-                "</data>"
-            "</array>"
+            "<value>"
+                "<array>"
+                    "<data>"
+                        "<value>"
+                            "<array>"
+                                "<data>"
+                                    "<value>"
+                                        "<i4>1</i4>"
+                                    "</value>"
+                                    "<value>"
+                                        "a"
+                                    "</value>"
+                                "</data>"
+                            "</array>"
+                        "</value>"
+                    "</data>"
+                "</array>"
+            "</value>"
         ),
     ),
     (
         {"foo": "bar"},
         (
-            "<struct>"
-              "<member>"
-                "<name>foo</name>"
-                "<value>bar</value>"
-              "</member>"
-            "</struct>"
+            "<value>"
+                "<struct>"
+                    "<member>"
+                        "<name>foo</name>"
+                        "<value>bar</value>"
+                    "</member>"
+                "</struct>"
+            "</value>"
         ),
     ),
 ]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -80,6 +80,42 @@ CASES = [
     ),
 ]
 
+CASES_COMPAT = [
+    ("Hello world!", "Hello world!"),
+    (
+        [[1, "a"]],
+        (
+            "<array>"
+                "<data>"
+                    "<value>"
+                        "<array>"
+                            "<data>"
+                                "<value>"
+                                    "<i4>1</i4>"
+                                "</value>"
+                                "<value>"
+                                    "a"
+                                "</value>"
+                            "</data>"
+                        "</array>"
+                    "</value>"
+                "</data>"
+            "</array>"
+        ),
+    ),
+    (
+        {"foo": "bar"},
+        (
+            "<struct>"
+              "<member>"
+                "<name>foo</name>"
+                "<value>bar</value>"
+              "</member>"
+            "</struct>"
+        ),
+    ),
+]
+
 
 def normalise_dict(d):
     """
@@ -102,7 +138,7 @@ def normalise_dict(d):
     return out
 
 
-@pytest.mark.parametrize("expected,data", CASES)
+@pytest.mark.parametrize("expected,data", CASES + CASES_COMPAT)
 def test_xml2py(expected, data):
     data = etree.fromstring(data)
     result = xml2py(data)


### PR DESCRIPTION
According to the specification in http://xmlrpc.com/spec.md values with
omitted types should be treated as strings