### PR TITLE
Fix empty string values become the string literal "None"

### DIFF
--- a/aiohttp_xmlrpc/common.py
+++ b/aiohttp_xmlrpc/common.py
@@ -169,7 +169,7 @@ def xml2py(value):
         return xml2py(value)
 
     XML2PY_TYPES.update({
-        "string": lambda x: str(x.text).strip(),
+        "string": lambda x: str(x.text or "").strip(),
         "struct": xml2struct,
         "array": xml2array,
         "base64": lambda x: Binary.fromstring(x.text),

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -26,6 +26,8 @@ CASES = [
 
     (None, "<nil/>"),
 
+    ("", "<string/>"),
+
     (
         [1404, "Something here", 1],
         (


### PR DESCRIPTION
Fixes https://github.com/mosquito/aiohttp-xmlrpc/issues/44.

**Changes:**
- Added failing test case for `<string/>` -> `""`
- Falsey `p.text` is now considered `""`, as in `unwrap_value()`