### PR TITLE
Add github links to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,7 @@ setup(
         ],
     },
     python_requires=">=3.5",
+    project_urls={
+        "Source": "https://github.com/mosquito/aiohttp-xmlrpc",
+    },
 )


### PR DESCRIPTION
There was no link from the PyPI page to this repository.