### PR TITLE
Allow nested methods to be called on client side

### DIFF
--- a/aiohttp_xmlrpc/client.py
+++ b/aiohttp_xmlrpc/client.py
@@ -23,7 +23,7 @@ class _Method:
         return _Method(self.__send, "%s.%s" % (self.__name, name))
 
     def __call__(self, *args, **kwargs):
-        return self.__send(self.__name, args, kwargs)
+        return self.__send(self.__name, *args, **kwargs)
 
 
 class ServerProxy(object):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -97,7 +97,7 @@ async def test_5_exception(client):
 
 async def test_6_unknown_method(client):
     with pytest.raises(ApplicationError):
-        await client["unknown_method"]()
+        await client.unknown_method()
 
 
 async def test_7_strings(aiohttp_client):


### PR DESCRIPTION
The code modification done here is largely inspired by what is done in the ['xmlrpc' built-in python library](https://github.com/python/cpython/blob/main/Lib/xmlrpc/client.py).

The code mechanism is about creating a "_Method" class that handle the "nested" calls (e.g. `A.foo()`).

In order to keep the `close()` method as it was before, an exception is added in the `__getattr__()` function of the `ServerProxy` class.

Signed-off-by: Armand Bénéteau <armand.beneteau@iot.bzh>