### PR TITLE
Allow custom method names other than the default on server side

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,10 +31,12 @@ Server example
 
     from aiohttp import web
     from aiohttp_xmlrpc import handler
-    from tornado.testing import *
+    from aiohttp_xmlrpc.handler import rename
 
 
     class XMLRPCExample(handler.XMLRPCView):
+
+        @rename("nested.test")
         def rpc_test(self):
             return None
 
@@ -47,6 +49,7 @@ Server example
         def rpc_args_kwargs(self, *args, **kwargs):
             return len(args) + len(kwargs)
 
+        @rename("nested.exception")
         def rpc_exception(self):
             raise Exception("YEEEEEE!!!")
 
@@ -56,6 +59,7 @@ Server example
 
     if __name__ == "__main__":
         web.run_app(app)
+
 
 
 
@@ -72,11 +76,11 @@ Client example
     client = ServerProxy("http://127.0.0.1:8080/", loop=loop)
 
     async def main():
-        print(await client.test())
+        # 'nested.test' method call
+        print(await client.nested.test())
 
-        # Or via __getitem__
-        method = client['args']
-        print(await method(1, 2, 3))
+        # 'args' method call
+        print(await client.args(1, 2, 3))
 
         client.close()
 

--- a/aiohttp_xmlrpc/handler.py
+++ b/aiohttp_xmlrpc/handler.py
@@ -42,6 +42,7 @@ class XMLRPCViewMeta(ABCMeta):
             if not key.startswith(instance.METHOD_PREFIX):
                 continue
 
+            # Get the value of the corresponding function
             value = getattr(instance, key)
 
             method_name = getattr(value, "__xmlrpc_name__", None)
@@ -49,6 +50,8 @@ class XMLRPCViewMeta(ABCMeta):
                 method_name = key.replace(instance.METHOD_PREFIX, "", 1)
 
             allowed_methods[method_name] = key
+
+            # Add the arg mapping in all cases
             argmapping[method_name] = inspect.getfullargspec(value)
 
         setattr(

--- a/aiohttp_xmlrpc/handler.py
+++ b/aiohttp_xmlrpc/handler.py
@@ -43,7 +43,11 @@ class XMLRPCViewMeta(ABCMeta):
                 continue
 
             value = getattr(instance, key)
-            method_name = key.replace(instance.METHOD_PREFIX, "", 1)
+
+            method_name = getattr(value, "__xmlrpc_name__", None)
+            if method_name is None:
+                method_name = key.replace(instance.METHOD_PREFIX, "", 1)
+
             allowed_methods[method_name] = key
             argmapping[method_name] = inspect.getfullargspec(value)
 
@@ -185,3 +189,10 @@ class XMLRPCView(View, metaclass=XMLRPCViewMeta):
             encoding="utf-8",
             pretty_print=cls.DEBUG,
         )
+
+
+def rename(new_name):
+    def decorator(func):
+        func.__xmlrpc_name__ = new_name
+        return func
+    return decorator

--- a/examples/client.py
+++ b/examples/client.py
@@ -7,14 +7,13 @@ client = ServerProxy("http://127.0.0.1:8080/", loop=loop)
 
 
 async def main():
-    print(await client.test())
+    # 'nested.test' method call
+    print(await client.nested.test())
 
-    # Or via __getitem__
-    method = client['args']
-    print(await method(1, 2, 3))
+    # 'args' method call
+    print(await client.args(1, 2, 3))
 
-    client.close()
-
+    await client.close()
 
 if __name__ == "__main__":
     loop.run_until_complete(main())

--- a/examples/server.py
+++ b/examples/server.py
@@ -1,8 +1,11 @@
 from aiohttp import web
 from aiohttp_xmlrpc import handler
+from aiohttp_xmlrpc.handler import rename
 
 
 class XMLRPCExample(handler.XMLRPCView):
+
+    @rename("nested.test")
     def rpc_test(self):
         return None
 
@@ -15,6 +18,7 @@ class XMLRPCExample(handler.XMLRPCView):
     def rpc_args_kwargs(self, *args, **kwargs):
         return len(args) + len(kwargs)
 
+    @rename("nested.exception")
     def rpc_exception(self):
         raise Exception("YEEEEEE!!!")
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -8,6 +8,7 @@ from aiohttp_xmlrpc.exceptions import ApplicationError
 from lxml import etree
 from lxml.builder import E
 
+from aiohttp_xmlrpc.handler import rename
 
 pytest_plugins = (
     "aiohttp.pytest_plugin",
@@ -51,6 +52,10 @@ class XMLRPCMain(handler.XMLRPCView):
 
     def rpc_dict_kw_only_args(self, d, *, foo, **kw):
         return (d, foo, kw)
+
+    @rename("method_with.new_name")
+    def rpc_ranamed(self):
+        return "renamed_function"
 
 
 class XMLRPCChild(XMLRPCMain):
@@ -214,3 +219,8 @@ async def test_13_kw_only_args(client):
         {"foo": "bar"}, foo=32, spam="egg"
     )
     assert result == [{"foo": "bar"}, 32, {"spam": "egg"}]
+
+
+async def test_14_method_renaming(client):
+    result = await client.method_with.new_name()
+    assert result == "renamed_function"

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -17,6 +17,7 @@ pytest_plugins = (
 
 
 class XMLRPCMain(handler.XMLRPCView):
+
     def rpc_test(self):
         return None
 
@@ -54,13 +55,18 @@ class XMLRPCMain(handler.XMLRPCView):
         return (d, foo, kw)
 
     @rename("method_with.new_name")
-    def rpc_ranamed(self):
+    def rpc_renamed(self):
         return "renamed_function"
 
 
 class XMLRPCChild(XMLRPCMain):
+
     def rpc_child(self):
         return 42
+
+    @rename("child.test")
+    def rpc_child_nested_method(self):
+        return "My name has the nested format and I am in child class"
 
 
 def create_app(loop):
@@ -224,3 +230,10 @@ async def test_13_kw_only_args(client):
 async def test_14_method_renaming(client):
     result = await client.method_with.new_name()
     assert result == "renamed_function"
+
+
+async def test_15_nested_method_in_child(aiohttp_xmlrpc_client):
+    client = await aiohttp_xmlrpc_client(create_app, path="/clone")
+
+    result = await client.child.test()
+    assert result == "My name has the nested format and I am in child class"


### PR DESCRIPTION
This new feature is useful for a user that wants to use dot ('.') in the xmlrpc method names available in its server.
Indeed, this is not possible in python function definition. 

Therefore, this feature can be used to "simulate" nested methods.

The implementation of this feature does not use true nested methods (i.e. methods in sub-classes of the main class, inheriting from handler.XMLRPCView).

Instead, it simply allows the user to overwrite some method names thanks to a `METHOD_NAMES` dictionary attribute in the user class (the one inheriting from `handler.XMLRPCView`). 
The default behavior is kept. So, this code is compatible with projects using an older version of `aiohttp-xmlrpc`.

This approach has been used in order to not modify the whole code structure of the 'handler.py' and still offer 'nested' methods from the client point of view.

The `README.rst` file and the tests have been updated and completed accordingly.

Signed-off-by: Armand Bénéteau <armand.beneteau@iot.bzh>