### PR TITLE
fix: return self in `__aenter__`

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/aiohttp_xmlrpc/client.py
+++ b/aiohttp_xmlrpc/client.py
@@ -128,8 +128,9 @@ class ServerProxy(object):
             # Magic method dispatcher
             return _Method(self.__remote_call, method_name)
 
-    def __aenter__(self):
-        return self.client.__aenter__()
+    async def __aenter__(self):
+        await self.client.__aenter__()
+        return self
 
     def __aexit__(self, exc_type, exc_val, exc_tb):
         return self.client.__aexit__(exc_type, exc_val, exc_tb)

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,6 +1,6 @@
-[pylava]
+[pylama]
 ignore=C901,E252,E131
 skip = *env*,.tox*,*build*
 
-[pylava:pycodestyle]
+[pylama:pycodestyle]
 max_line_length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
 
 [testenv:lint]
 deps =
-    pylava
+    pylama
 
 commands=
-    pylava -o pylava.ini .
+    pylama -o pylama.ini .

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py3{6-10}
 
 [testenv]
-passenv = COVERALLS_* GITHUB_* TEST_* FORCE_COLOR
+passenv = COVERALLS_*, GITHUB_*, TEST_*, FORCE_COLOR
 
 extras =
   develop


### PR DESCRIPTION
`ServerProxy`'s `__aenter__` return an `aiohttp.client.ClientSession` instance, which is confusing.